### PR TITLE
Adding korea to our well known file.

### DIFF
--- a/.well-known/stellar.toml
+++ b/.well-known/stellar.toml
@@ -93,3 +93,16 @@ anchor_asset = "European Government Bonds"
 status = "live"
 attestation_of_reserve = "https://app.etherfuse.com/legal/proof-of-reserves"
 redemption_instructions = "Go to app.etherfuse.com and offramp to a bank account or exchange for the equivelent USDC of the underlying assets"
+
+[[CURRENCIES]]
+code = "KTB"
+issuer = "GCRYUGD5NVARGXT56XEZI5CIFCQETYHAPQQTHO2O3IQZTHDH4LATMYWC"
+name = "Etherfuse KTB"
+desc = "The Korean Treasury Stablebond provides tokenized exposure to Korean sovereign debt through short-term Korean Treasury Bonds (KTBs)."
+image = "https://stablebonds.s3.us-west-2.amazonaws.com/stablebond/spl-ktb.png"
+is_asset_anchored = true
+anchor_asset_type = "bond"
+anchor_asset = "Korean Treasury Bonds"
+status = "live"
+attestation_of_reserve = "https://app.etherfuse.com/legal/proof-of-reserves"
+redemption_instructions = "Go to app.etherfuse.com and offramp to a bank account or exchange for the equivelent USDC of the underlying assets"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a new token entry to the Stellar well-known file.
> 
> - Introduces `[[CURRENCIES]]` entry for `KTB` (Etherfuse KTB) in `.well-known/stellar.toml` with issuer `GCRYUGD5NVARGXT56XEZI5CIFCQETYHAPQQTHO2O3IQZTHDH4LATMYWC`, image, attestation URL, and redemption instructions
> - Configures as an anchored `bond` to "Korean Treasury Bonds" with `status = "live"`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1b1fdbe392fb32c33f3fd3d769744c83bc1e6afd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->