### PR TITLE
Add sandbox USDC to testnet stellar.toml

### DIFF
--- a/.well-known/stellar-testnet.toml
+++ b/.well-known/stellar-testnet.toml
@@ -80,3 +80,14 @@ anchor_asset = "MXN"
 status = "test"
 attestation_of_reserve = "https://devnet.etherfuse.com/legal/proof-of-reserves"
 redemption_instructions = "Go to devnet.etherfuse.com and offramp to a bank account or exchange for the equivelent USDC of the underlying assets"
+
+[[CURRENCIES]]
+code = "USDC"
+issuer = "GC3CW7EDYRTWQ635VDIGY6S4ZUF5L6TQ7AA4MWS7LEQDBLUSZXV7UPS4"
+name = "USD Coin (sandbox)"
+desc = "Etherfuse sandbox USDC. Self-issued on testnet to simulate the on/off-ramp flow; NOT real Circle USDC and has no off-chain value."
+image = "https://www.centre.io/images/usdc/usdc-icon-86074d9d49.png"
+is_asset_anchored = true
+anchor_asset_type = "fiat"
+anchor_asset = "USD"
+status = "test"


### PR DESCRIPTION
## Summary
- Adds a `USDC` `[[CURRENCIES]]` entry to `stellar-testnet.toml` under the sandbox issuer `GC3CW7EDYRTWQ635VDIGY6S4ZUF5L6TQ7AA4MWS7LEQDBLUSZXV7UPS4` (same issuer as CETES/KTB/USTRY/CARN/CZERO).
- Description explicitly flags it as self-issued sandbox USDC, not real Circle USDC, so nobody confuses it for mainnet at a glance.

## Why
The Bond UI on testnet resolves `sand.etherfuse.com/.well-known/stellar.toml` to build its asset catalog, then computes SAC contract IDs from `(code, issuer, network)` to fetch smart-wallet (C-address) balances via Soroban RPC. Without USDC in the TOML, the catalog has no way to surface the USDC balance — even though the asset is issued on testnet and the SAC `CDYDS67YY3YXK3MGWFNZXOTVZBS2CJEEXGI6UF332TZMJGOD4TZL3Q4C` is now wrapped.

## Changes
- `.well-known/stellar-testnet.toml`: one new `[[CURRENCIES]]` block for USDC.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new `[[CURRENCIES]]` entry in a testnet TOML config and does not change application logic or sensitive flows.
> 
> **Overview**
> Adds a new `[[CURRENCIES]]` block for **sandbox `USDC`** to `.well-known/stellar-testnet.toml` under the existing testnet issuer, including metadata and an explicit description that it is *self-issued on testnet* and **not** Circle USDC.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f58939e7eb66511017f23f61e08f91f3466d4c99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->