### PR TITLE
Fix sandbox USDC issuer to match tony's STELLAR_USDC_ISSUER

### DIFF
--- a/.well-known/stellar-testnet.toml
+++ b/.well-known/stellar-testnet.toml
@@ -83,7 +83,7 @@ redemption_instructions = "Go to devnet.etherfuse.com and offramp to a bank acco
 
 [[CURRENCIES]]
 code = "USDC"
-issuer = "GC3CW7EDYRTWQ635VDIGY6S4ZUF5L6TQ7AA4MWS7LEQDBLUSZXV7UPS4"
+issuer = "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
 name = "USD Coin (sandbox)"
 desc = "Etherfuse sandbox USDC. Self-issued on testnet to simulate the on/off-ramp flow; NOT real Circle USDC and has no off-chain value."
 image = "https://www.centre.io/images/usdc/usdc-icon-86074d9d49.png"


### PR DESCRIPTION
## Summary
- Sand backend (tony + nero) issues USDC from `GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5` (per `terraform/sand-tony/env_vars.tf` and `nero/.../stablecoin_config.rs`), but this TOML advertised the Etherfuse bond issuer `GC3CW7ED…` instead.
- The bond UI derives the USDC SAC contract id from the TOML's issuer, so for C-address wallets the SAC balance read was hitting an unrelated contract and returning 0 — USDC deliveries (e.g. FX onramp final hop via SAC `transfer`) landed on-chain but never appeared in "Current Holdings".

## Changes
- `.well-known/stellar-testnet.toml`: USDC issuer `GC3CW7ED…UPS4` → `GBBD47IF…FLA5`.

## Verified delivery
- FX onramp `09f9c328-6063-48ec-af8f-ef311836eda7` SAC transfer: https://stellar.expert/explorer/testnet/tx/e50e6eaf74a5c592aab8f1f55e1e90800d81522785822bfa1041a8834aaccf14 → 19.5142598 USDC to `CCRG4PS4ORMPC4HZKVVTPPNE52JWUDLUJMDFPP4TV7QMS4JGJ6LEOWUT`, asset `USDC:GBBD47IF…FLA5`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk configuration change, but it affects how clients derive the USDC asset/SAC contract from `.well-known/stellar-testnet.toml`, so a wrong value could make balances appear missing.
> 
> **Overview**
> Updates `.well-known/stellar-testnet.toml` to change the advertised `USDC` issuer from `GC3CW7ED…` to `GBBD47IF…`, aligning the testnet metadata with the sandbox backend issuer so wallet/UI lookups resolve the correct asset/contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b47b492937a0345ce49e77cf63f788f550157dd2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->