### PR TITLE
Adding GILTS metadata to stellar.

### DIFF
--- a/.well-known/stellar.toml
+++ b/.well-known/stellar.toml
@@ -106,3 +106,16 @@ anchor_asset = "Korean Treasury Bonds"
 status = "live"
 attestation_of_reserve = "https://app.etherfuse.com/legal/proof-of-reserves"
 redemption_instructions = "Go to app.etherfuse.com and offramp to a bank account or exchange for the equivelent USDC of the underlying assets"
+
+[[CURRENCIES]]
+code = "GILTS"
+issuer = "GCRYUGD5NVARGXT56XEZI5CIFCQETYHAPQQTHO2O3IQZTHDH4LATMYWC"
+name = "Etherfuse GILTS"
+desc = "Etherfuse GILTS provide tokenized exposure to UK sovereign debt through short-term UK Gilts, backed by the full faith and credit of the United Kingdom government."
+image = "https://stablebonds.s3.us-west-2.amazonaws.com/stablebond/spl-gilts.png"
+is_asset_anchored = true
+anchor_asset_type = "bond"
+anchor_asset = "UK Gilts"
+status = "live"
+attestation_of_reserve = "https://app.etherfuse.com/legal/proof-of-reserves"
+redemption_instructions = "Go to app.etherfuse.com and offramp to a bank account or exchange for the equivelent USDC of the underlying assets"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only changes to public asset metadata; no application or on-chain logic is modified.
> 
> **Overview**
> Registers **Etherfuse GILTS** in `.well-known/stellar.toml` as a new `[[CURRENCIES]]` entry for UK Gilts–backed stablebonds (same issuer as other Etherfuse assets), including bond anchoring, live status, proof-of-reserves URL, and redemption instructions consistent with existing bond listings.
> 
> Also adds **`redemption_instructions`** to the **KTB** entry, which previously lacked that field while other currencies already had it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 714e3f9217589a1cf4a88127d900449f03193f7e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->