### PR TITLE
Adding MEXe to wellknown toml.

### DIFF
--- a/.well-known/stellar.toml
+++ b/.well-known/stellar.toml
@@ -119,3 +119,16 @@ anchor_asset = "UK Gilts"
 status = "live"
 attestation_of_reserve = "https://app.etherfuse.com/legal/proof-of-reserves"
 redemption_instructions = "Go to app.etherfuse.com and offramp to a bank account or exchange for the equivelent USDC of the underlying assets"
+
+[[CURRENCIES]]
+code = "MEXe"
+issuer = "GCRYUGD5NVARGXT56XEZI5CIFCQETYHAPQQTHO2O3IQZTHDH4LATMYWC"
+name = "Etherfuse MEXe"
+desc = "Etherfuse MEXe is the Principal Token of Etherfuse CETES — Certificados de la Tesorería de la Federación, Mexico's short-term sovereign debt securities issued by the Ministry of Finance. CETES are BBB- rated, settled through INDEVAL (Instituto para el Depósito de Valores), and underpin Mexico's monetary policy and government financing.\n\nEach MEXe represents the principal claim on one unit of Etherfuse CETES at maturity, separated from the yield component. Holders can unwrap MEXe at any time to recover the underlying CETES at its present value."
+image = "https://stablebonds.s3.us-west-2.amazonaws.com/stablebond/etherfuse_mexe.png"
+is_asset_anchored = true
+anchor_asset_type = "crypto"
+anchor_asset = "Etherfuse CETES"
+status = "live"
+attestation_of_reserve = "https://app.etherfuse.com/legal/proof-of-reserves"
+redemption_instructions = "Go to app.etherfuse.com and offramp to a bank account or exchange for the equivelent USDC of the underlying assets"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Metadata-only changes to the public Stellar TOML with no application or on-chain logic.
> 
> **Overview**
> Updates **`.well-known/stellar.toml`** so Stellar wallets and anchors can discover two asset metadata changes.
> 
> **GILTS** now includes **`redemption_instructions`** (same offramp/USDC wording as other Etherfuse currencies), which was previously missing for that entry.
> 
> A new **`[[CURRENCIES]]`** block registers **MEXe** (`Etherfuse MEXe`): principal token anchored to **Etherfuse CETES**, with description, image, live status, proof-of-reserves link, and redemption instructions consistent with the rest of the file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4af99c7accecb6c30a8ed279f406801b6abdf92b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->